### PR TITLE
Minor typo updates to Flask API article

### DIFF
--- a/_posts/2019-5-20-flask-api-example.md
+++ b/_posts/2019-5-20-flask-api-example.md
@@ -18,7 +18,7 @@ After much trial-and-error, I have come up with a set of patterns that work real
 - `pytest`, for testing
 - Marshmallow for data serialization/deserialization and input validation
 - SQLAlchemy as an ORM
-- Flast-RESTplus for Swagger documentation
+- Flask-RESTplus for Swagger documentation
 - [flask_accepts](https://github.com/apryor6/flask_accepts), a library I wrote that marries Marshmallow with Flask-RESTplus, giving you the control of marshmallow with the awesome Swagger documentation from flask-RESTplus.
 
 In a nutshell, Flask requests are routed using RESTplus Resources, input data is validated with a Marshmallow schema, some data processing occurs via a service interacting with a model, and then the output is serialized back to JSON on the way out, again using Marshmallow. All of this is documented via interactive Swagger docs, and [`flask_accepts`](https://github.com/apryor6/flask_accepts) serves as glue that under-the-hood maps each Marshmallow schema into an equivalent Flask-RESTplus API model so that these two amazing-but-somewhat-incompatible technologies can happily be used together.
@@ -191,7 +191,7 @@ def test_WidgetInterface_works(interface: WidgetInterface):
 
 ### Schema
 
-Marshmallow chemas are responsible for handling input/output operations for the API and are where renaming conventions are handled. JavaScript is the language of the web, and in JavaScript the preferred style for variables is lowerCamelCase, whereas in python snake_case is preferred. The schema is the perfect place to handle this translation as it is the layer between your API and the outside world. Marshmallow is an amazing technology that you can learn more about [here](https://marshmallow.readthedocs.io/en/3.0/), and it can do an enormous number of tasks that are much more complicated than the example I give below. For example, you can use the `post_load` hook from Marshmallow to declare what object(s) to create when the `Schema.load` method is invoked, which will automatically synergize with `flask_accepts` to provide a fully-instantiated object in `request.parsed_obj`, for example.
+Marshmallow schemas are responsible for handling input/output operations for the API and are where renaming conventions are handled. JavaScript is the language of the web, and in JavaScript the preferred style for variables is lowerCamelCase, whereas in python snake_case is preferred. The schema is the perfect place to handle this translation as it is the layer between your API and the outside world. Marshmallow is an amazing technology that you can learn more about [here](https://marshmallow.readthedocs.io/en/3.0/), and it can do an enormous number of tasks that are much more complicated than the example I give below. For example, you can use the `post_load` hook from Marshmallow to declare what object(s) to create when the `Schema.load` method is invoked, which will automatically synergize with `flask_accepts` to provide a fully-instantiated object in `request.parsed_obj`, for example.
 
 ```python
 from marshmallow import fields, Schema


### PR DESCRIPTION
I spotted some small typos in an otherwise excellent blog post. Hope this is useful.

Flast --> Flask
chemas --> schemas